### PR TITLE
allow Node.js-style explicit commonjs (.cjs) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Supported options:
         {
             exclude(fileName, chunck) {
                 // exclude if not a .js/.mjs file
-                return !/\.m?js/i.test(fileName);
+                return !/\.[cm]?js/i.test(fileName);
             }
         }
 

--- a/esm-webpack-plugin.js
+++ b/esm-webpack-plugin.js
@@ -2,7 +2,7 @@ const ConcatSource = require("webpack-sources").ConcatSource;
 const MultiModule = require("webpack/lib/MultiModule");
 const PLUGIN_NAME = "EsmWebpackPlugin";
 const warn = msg => console.warn(`[${PLUGIN_NAME}] ${msg}`);
-const IS_JS_FILE = /\.m?js$/i;
+const IS_JS_FILE = /\.[cm]?js$/i;
 const nonJsFiles = fileName => !IS_JS_FILE.test(fileName);
 
 /**


### PR DESCRIPTION
Node.js allows not only to explicitly declare ECMAScript module files as .mjs but also commonjs files as .cjs.
Source: https://nodejs.org/dist/latest-v12.x/docs/api/esm.html#esm_enabling